### PR TITLE
Add per-role tech stack tags to experience section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -660,6 +660,30 @@ section:nth-child(6) { animation-delay: 0.5s; }
   color: var(--color-accent);
 }
 
+.tech-tags {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-sm);
+  padding-left: 0;
+}
+
+.tech-tags li {
+  margin-bottom: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  background: var(--color-peach);
+  padding: 0.2rem 0.7rem;
+  border-radius: var(--radius-pill);
+  line-height: 1.4;
+}
+
+.tech-tags li::marker {
+  content: "";
+}
+
 /* Education */
 .education-list {
   display: flex;
@@ -1245,6 +1269,23 @@ footer::before {
 
   .experience-item li::marker {
     color: #666;
+  }
+
+  .tech-tags {
+    margin-top: 2pt;
+    padding-left: 0;
+    gap: 3pt;
+  }
+
+  .tech-tags li {
+    font-size: 7pt;
+    font-weight: 600;
+    color: #333;
+    background: transparent;
+    border: 0.5pt solid #bbb;
+    padding: 0.5pt 4pt;
+    border-radius: 6pt;
+    line-height: 1.3;
   }
 
   /* ===== Education ===== */

--- a/index.html
+++ b/index.html
@@ -68,6 +68,12 @@
               <li>Improved speech recognition accuracy from ~60% to ~90%</li>
               <li>Championed adoption of AI coding tools within the team</li>
             </ul>
+            <ul class="tech-tags" aria-label="Technologies">
+              <li>Python</li>
+              <li>Pipecat</li>
+              <li>TypeScript</li>
+              <li>React</li>
+            </ul>
           </div>
 
           <div class="experience-item">
@@ -90,6 +96,12 @@
               <li>Built LLM-powered MVP for automated time tracking in 3 months</li>
               <li>Conducted technical sales and problem validation interviews</li>
               <li>Focused business idea from process management software to time tracking as a shared pain within the industry</li>
+            </ul>
+            <ul class="tech-tags" aria-label="Technologies">
+              <li>C#</li>
+              <li>.NET</li>
+              <li>Azure</li>
+              <li>Semantic Kernel</li>
             </ul>
           </div>
 
@@ -122,6 +134,12 @@
               <li>Started managers roundtable for cross-team problem solving</li>
               <li>Introduced continuous feedback process replacing biannual reviews</li>
             </ul>
+            <ul class="tech-tags" aria-label="Technologies">
+              <li>Python</li>
+              <li>Django</li>
+              <li>NetSuite</li>
+              <li>GCP</li>
+            </ul>
           </div>
 
           <div class="experience-item">
@@ -131,6 +149,12 @@
             </div>
             <p class="experience-company">Swappie</p>
             <p>Factory software team. Integrated Blancco diagnostics and erasure into operations. Led the NetSuite ERP integration project, streamlining phone refurbishment processes. Promoted to manager based on project leadership.</p>
+            <ul class="tech-tags" aria-label="Technologies">
+              <li>Python</li>
+              <li>Django</li>
+              <li>NetSuite</li>
+              <li>GCP</li>
+            </ul>
           </div>
 
           <div class="experience-item">
@@ -144,6 +168,14 @@
               <li>Built backend for the React Native mobile application</li>
               <li>Integrated CRM and portfolio management systems</li>
               <li>Managed cloud release pipelines and infrastructure</li>
+            </ul>
+            <ul class="tech-tags" aria-label="Technologies">
+              <li>C#</li>
+              <li>.NET</li>
+              <li>TypeScript</li>
+              <li>React</li>
+              <li>React Native</li>
+              <li>Azure</li>
             </ul>
           </div>
 


### PR DESCRIPTION
## Summary
Adds tech stack tags to each work experience item, giving recruiters and ATS scans concrete languages/frameworks per role.

## Roles tagged
- **Sono (Voice AI Startup)** — Python · Pipecat · TypeScript · React
- **Adeu** — C# · .NET · Azure · Semantic Kernel
- **Swappie** (both roles) — Python · Django · NetSuite · GCP
- **Taaleri** — C# · .NET · TypeScript · React · React Native · Azure

## Design
- **Web**: peach pill tags in wine-red text, matching the site palette
- **Print/PDF**: ink-light outlined tags (thin border, no fill) — stays crisp and toner-friendly
- Semantic `<ul class="tech-tags">` with `aria-label="Technologies"`
- Verified both web and print render; CV still fits one A4 page